### PR TITLE
Markdown style fixes

### DIFF
--- a/src/components/outputer.vue
+++ b/src/components/outputer.vue
@@ -32,7 +32,6 @@
     color: #616161;
     box-shadow: 4px 5px 3px #aaa;
     white-space: normal;
-    word-break: break-all;
     overflow-y: scroll;
 	}
 </style>

--- a/static/markdown.less
+++ b/static/markdown.less
@@ -14,7 +14,7 @@ table{
 code {
   padding: 2px 4px;
   font-size: 90%;
-  font-family: inherit;
+  font-family: monospace;
   color: #c7254e;
   background-color: #f9f2f4;
   border-radius: 4px;


### PR DESCRIPTION
Nice project! I tried to use it in real life and it works really well, good job!

A few things annoyed me though :
- When you try to put some `code();` in the editor, the produced markdown isn't monospaced which feels weird
- When you type a long sentence that is longer than one line, there is a high chance that the word at the end will be cut in 2 :

<img width="392" alt="screen shot 2016-10-05 at 15 05 22" src="https://cloud.githubusercontent.com/assets/1416801/19114349/f88b14be-8b0d-11e6-8b8b-9038fa0013f4.png">

This PR aims to fix these 2 things.
